### PR TITLE
feat(InfinitePower): Add Attack Power stat type to UI

### DIFF
--- a/modules/InfinitePower/InfinitePower.lua
+++ b/modules/InfinitePower/InfinitePower.lua
@@ -48,6 +48,7 @@ local STAT_TYPES = {
     {id = 5, name = "Crit Rating", shortName = "CRIT", icon = "Interface\\Icons\\Ability_Rogue_Rupture"},
     {id = 6, name = "Haste Rating", shortName = "HASTE", icon = "Interface\\Icons\\Spell_Nature_Bloodlust"},
     {id = 7, name = "Spell Power", shortName = "SP", icon = "Interface\\Icons\\Spell_Holy_HolySmite"},
+    {id = 8, name = "Attack Power", shortName = "AP", icon = "Interface\\Icons\\Ability_Warrior_OffensiveStance"},
 }
 
 -- Equipment slot ID to name mapping (for gear bonus display)


### PR DESCRIPTION
## Description

Add Attack Power as a displayable stat type in the InfinitePower addon module to match the corresponding server-side addition in `elegast_core_v2`.

## Changes

- Add Attack Power entry to `STAT_TYPES` table:
  - `id = 8`
  - `name = "Attack Power"`
  - `shortName = "AP"`
  - `icon = "Interface\\Icons\\Ability_Warrior_OffensiveStance"`

## Related

- Server-side PR: [elegast_core_v2#113](https://github.com/elegast-me/elegast_core_v2/pull/113)
- Issue: #5

## Testing

After updating addon files:
1. Equip items with Attack Power stats (e.g., "of Power" random enchants)
2. Verify gear bonus tooltip shows Attack Power stat with [+X Attack Power] format
3. Verify Attack Power appears in stat allocation menu for physical DPS classes

Resolves: #5