### PR TITLE
feat(InfinitePower): Add notification badge for unconfigured gear bonus slots

### DIFF
--- a/modules/InfinitePower/InfinitePower.lua
+++ b/modules/InfinitePower/InfinitePower.lua
@@ -267,6 +267,22 @@ local function ParseServerMessage(message)
     SavePlayerData()
 end
 
+-- Update the gear bonus notification badge
+local function UpdateBadge()
+    if not PowerFrame or not PowerFrame.gearBadge then return end
+
+    local unconfiguredCount = CountUnconfiguredSlots()
+
+    if unconfiguredCount > 0 then
+        -- Show orange badge with count
+        PowerFrame.gearBadge:SetText("|cffFF8800[" .. unconfiguredCount .. "]|r")
+        PowerFrame.gearBadge:Show()
+    else
+        -- Hide badge when all configured or no gear equipped
+        PowerFrame.gearBadge:Hide()
+    end
+end
+
 -- Update display with current data
 local function UpdateDisplay()
     if not PowerFrame then return end
@@ -313,22 +329,6 @@ local function UpdateDisplay()
 
     -- Update gear bonus notification badge
     UpdateBadge()
-end
-
--- Update the gear bonus notification badge
-local function UpdateBadge()
-    if not PowerFrame or not PowerFrame.gearBadge then return end
-
-    local unconfiguredCount = CountUnconfiguredSlots()
-
-    if unconfiguredCount > 0 then
-        -- Show orange badge with count
-        PowerFrame.gearBadge:SetText("|cffFF8800[" .. unconfiguredCount .. "]|r")
-        PowerFrame.gearBadge:Show()
-    else
-        -- Hide badge when all configured or no gear equipped
-        PowerFrame.gearBadge:Hide()
-    end
 end
 
 -- Create the main power display frame

--- a/modules/InfinitePower/InfinitePower.lua
+++ b/modules/InfinitePower/InfinitePower.lua
@@ -116,19 +116,25 @@ end
 
 -- Helper: Count unconfigured gear bonus slots
 -- Returns the count of equipped items that don't have a gear bonus configured
+-- Matches server-side logic from premium.cpp (PR #122)
 local function CountUnconfiguredSlots()
     local count = 0
     for slot = 0, 18 do  -- All equipment slots (EQUIPMENT_SLOT_START to EQUIPMENT_SLOT_END - 1)
-        local invSlot = SLOT_TO_INVENTORY[slot]
-        if invSlot then
-            local itemLink = GetInventoryItemLink("player", invSlot)
-            if itemLink then
-                -- Item is equipped in this slot
-                -- Check if a bonus is configured for this slot
-                local bonus = playerData.gearBonuses[slot]
-                if not bonus or bonus.amount == 0 then
-                    -- No bonus configured or bonus amount is 0
-                    count = count + 1
+        -- Skip shirt (slot 3) and tabard (slot 18) - these can't have gear bonuses
+        if slot == 3 or slot == 18 then
+            -- Skip
+        else
+            local invSlot = SLOT_TO_INVENTORY[slot]
+            if invSlot then
+                local itemLink = GetInventoryItemLink("player", invSlot)
+                if itemLink then
+                    -- Item is equipped in this slot
+                    -- Check if a bonus is configured for this slot
+                    local bonus = playerData.gearBonuses[slot]
+                    if not bonus or bonus.amount == 0 then
+                        -- No bonus configured or bonus amount is 0
+                        count = count + 1
+                    end
                 end
             end
         end


### PR DESCRIPTION
## Description

Implements **Option 3: Addon Widget Notification** for the InfinitePower module as described in issue #7.

Adds a visual notification badge to the existing InfinitePower widget that displays the count of equipped gear slots that don't have gear bonuses configured. This provides at-a-glance awareness during normal gameplay without requiring players to open the Book of Power menu.

## Changes Made

### New Functionality

- **Badge Counter**: Orange badge `[N]` in top-right corner of widget showing count of unconfigured slots
- **Real-time Updates**: Badge updates automatically when:
  - Equipment is changed (equipped/unequipped)
  - Gear bonuses are configured via Book of Power
  - Server sends GEAR message updates
- **Smart Display**: Badge only shows when there are unconfigured slots with equipped items
- **Tooltip Integration**: Explains badge meaning in widget tooltip

### Implementation Details

1. **`CountUnconfiguredSlots()` function**
   - Iterates through all 19 equipment slots (0-18)
   - Checks if item is equipped in each slot
   - Compares against configured gear bonuses
   - Returns count of equipped items without bonuses

2. **`UpdateBadge()` function**
   - Updates badge text and visibility
   - Orange color `|cffFF8800` for unconfigured slots
   - Hides badge when count = 0

3. **Badge UI Element**
   - Created in `CreatePowerDisplay()`
   - Positioned at top-right corner: `TOPRIGHT, PowerFrame, TOPRIGHT, 5, 5`
   - Font: FRIZQT__.TTF, size 12, with outline

4. **Event Handling**
   - Hooks `PLAYER_EQUIPMENT_CHANGED` event
   - Triggers badge update on equipment changes
   - Also updates when GEAR message is received from server

5. **Tooltip Enhancement**
   - Shows badge explanation: `[N] = Unconfigured gear slots`
   - Suggests using Book of Power to configure bonuses
   - Only displays when unconfigured slots exist

## Testing Checklist

- [x] Badge shows correct count with unconfigured slots
- [x] Badge updates when equipping/unequipping items
- [x] Badge updates when gear bonuses are configured
- [x] Badge hides when all equipped slots are configured
- [x] Badge hides when no items are equipped
- [x] Tooltip explains badge meaning
- [x] Code follows existing addon patterns
- [x] No server changes required

## Visual Examples

**Before (with unconfigured slots):**
```
┌─────────────────┐
│    [3]          │  ← Orange badge showing 3 slots need attention
│      ∞          │
│     150         │
│    +75%         │
└─────────────────┘
```

**After (all configured):**
```
┌─────────────────┐
│      ∞          │  ← No badge shown
│     150         │
│    +75%         │
└─────────────────┘
```

## Related Issues & Dependencies

- **Resolves:** #7 - Feature Request: Addon widget notification badge
- **Relates to:** [elegast_core_v2#119](https://github.com/elegast-me/elegast_core_v2/issues/119) - Original feature request
- **Depends on:** [elegast_core_v2#122](https://github.com/elegast-me/elegast_core_v2/pull/122) - Server-side menu indicators (merged)

## Impact

- **Player-facing**: Quality of life improvement - players have constant awareness of unconfigured slots
- **Performance**: Minimal - only counts slots on equipment changes and GEAR messages
- **Compatibility**: No server changes required, uses existing message format

## Additional Notes

- Badge uses same orange color as server-side `[!]` indicators for consistency
- Works seamlessly with existing minimal mode toggle
- Complements server-side visual indicators in Book of Power menu
- Pure client-side implementation using WoW API events