### PR TITLE
fix: remove duplicate ThreatenedAzeroth entry from .toc (Issue #14)

### DIFF
--- a/ElegastCore.toc
+++ b/ElegastCore.toc
@@ -12,4 +12,3 @@ Core.lua
 modules\SpeedBuff\SpeedBuff.lua
 modules\InfinitePower\InfinitePower.lua
 modules\ThreatenedAzeroth\ThreatenedAzeroth.lua
-modules\ThreatenedAzeroth\ThreatenedAzeroth.lua


### PR DESCRIPTION
## Changes Proposed

**1 line removed.** `ThreatenedAzeroth.lua` was listed twice in `ElegastCore.toc`.

## Effect of the bug

WoW loaded the file twice, so the module registered twice. `Core.lua:RegisterModule`
catches that and prints to chat:

```
|cffFF6666ElegastCore Warning:|r Module 'ThreatenedAzeroth' already registered, overwriting...
```

So **every player saw a red warning on every login**, and the second module table
replaced the first — orphaning anything the first load had created.

Present since the initial commit (`3c3e79b`).

## Verification

```
SpeedBuff            1
InfinitePower        1
ThreatenedAzeroth    1
```

Each module now listed exactly once. Load order is preserved (Core first, then modules
in their original sequence).

- [ ] **Not verified in a running client** — no WoW client available here. The change is
      a single deleted line in a manifest and the remaining entries are unchanged, so
      risk is minimal, but the warning disappearing should be confirmed on next login.

## Issues Addressed
- Closes #14

## Context

Found while surveying this addon alongside the classless work in
`elegast-me/ElegastCore-Classless`. Unrelated to classless — a pre-existing defect that
happened to be trivial to fix.
