### PR TITLE
feat: show progress to the next Infinite Power stack (Issue #18)

### DIFF
--- a/modules/InfinitePower/InfinitePower.lua
+++ b/modules/InfinitePower/InfinitePower.lua
@@ -551,6 +551,10 @@ local function CreatePowerDisplay()
     progressBg:SetAllPoints(progressBar)
     progressBg:SetVertexColor(0.1, 0.1, 0.1, 0.8)
 
+    -- UpdateProgressBar re-anchors per display mode, but anchor once here too so
+    -- the frame is never laid out unpositioned if that call order ever changes.
+    progressBar:SetPoint("TOP", PowerFrame, "BOTTOM", 0, -26)
+
     PowerFrame.progressBar = progressBar
     PowerFrame.progressShown = 0    -- what the bar is drawing right now
     PowerFrame.progressTarget = 0   -- what the data says it should be

--- a/modules/InfinitePower/InfinitePower.lua
+++ b/modules/InfinitePower/InfinitePower.lua
@@ -2,11 +2,13 @@
     InfinitePower Module for ElegastCore
     Displays XP stacks, stat points, gear bonuses, and allows stat allocation
     Added animation notifications when IP stacks are gained (similar to SpeedBuff)
+    Added a progress bar for the next stack, so accumulation is visible without
+    hovering for the tooltip (Issue #18)
 ]]--
 
 -- Create module table
 local InfinitePowerModule = {
-    version = "1.1.2",
+    version = "1.2.0",
     name = "InfinitePower"
 }
 
@@ -370,6 +372,52 @@ local function UpdateBadge()
     end
 end
 
+-- Progress bar geometry. Width matches the 60x60 widget frame.
+local PROGRESS_BAR_WIDTH = 60
+local PROGRESS_BAR_HEIGHT = 6
+local PROGRESS_TWEEN_DURATION = 0.35
+
+-- Kills and quests are alternative paths to the same stack -- the tooltip says
+-- "complete either" -- so the bar tracks whichever is closer, and takes the
+-- tooltip's colour for that path so the two agree at a glance.
+local function CalculateProgress()
+    local killFraction = 0
+    if playerData.killsNeeded and playerData.killsNeeded > 0 then
+        killFraction = playerData.killsThisStack / playerData.killsNeeded
+    end
+
+    local questFraction = 0
+    if playerData.questsNeeded and playerData.questsNeeded > 0 then
+        questFraction = playerData.questsThisStack / playerData.questsNeeded
+    end
+
+    if questFraction > killFraction then
+        return math.min(questFraction, 1), 0.4, 1.0, 1.0
+    end
+    return math.min(killFraction, 1), 1.0, 1.0, 0.4
+end
+
+-- Repositions and retargets the bar. Minimal mode drops the icon and pulls the
+-- text into the middle of the frame, so the bar moves up to sit right under it.
+local function UpdateProgressBar(isMinimal)
+    if not PowerFrame or not PowerFrame.progressBar then return end
+
+    local bar = PowerFrame.progressBar
+    local fraction, r, g, b = CalculateProgress()
+
+    bar:SetStatusBarColor(r, g, b)
+    bar:ClearAllPoints()
+    bar:SetPoint("TOP", PowerFrame, "BOTTOM", 0, isMinimal and -4 or -26)
+    bar:Show()
+
+    if PowerFrame.progressTarget ~= fraction then
+        PowerFrame.progressTarget = fraction
+        PowerFrame.progressTweenTime = 0
+        PowerFrame.progressTweenFrom = PowerFrame.progressShown or 0
+        PowerFrame.isProgressTweening = true
+    end
+end
+
 -- Update display with current data
 local function UpdateDisplay()
     if not PowerFrame then return end
@@ -416,6 +464,9 @@ local function UpdateDisplay()
 
     -- Update gear bonus notification badge
     UpdateBadge()
+
+    -- Update progress toward the next stack (Issue #18)
+    UpdateProgressBar(isMinimal)
 
     -- Pulse effect when gaining new stack (similar to SpeedBuff, only on increases)
     if PowerFrame.lastStack < playerData.xpStacks then
@@ -484,6 +535,25 @@ local function CreatePowerDisplay()
     gearBadge:SetText("")
     gearBadge:Hide()  -- Initially hidden
     PowerFrame.gearBadge = gearBadge
+
+    -- Progress to the next stack (Issue #18). The server sends kill and quest
+    -- progress on every update; until now it only surfaced in the tooltip.
+    local progressBar = CreateFrame("StatusBar", nil, PowerFrame)
+    progressBar:SetWidth(PROGRESS_BAR_WIDTH)
+    progressBar:SetHeight(PROGRESS_BAR_HEIGHT)
+    progressBar:SetStatusBarTexture("Interface\\TargetingFrame\\UI-StatusBar")
+    progressBar:GetStatusBarTexture():SetHorizTile(false)
+    progressBar:SetMinMaxValues(0, 1)
+    progressBar:SetValue(0)
+
+    local progressBg = progressBar:CreateTexture(nil, "BACKGROUND")
+    progressBg:SetTexture("Interface\\TargetingFrame\\UI-StatusBar")
+    progressBg:SetAllPoints(progressBar)
+    progressBg:SetVertexColor(0.1, 0.1, 0.1, 0.8)
+
+    PowerFrame.progressBar = progressBar
+    PowerFrame.progressShown = 0    -- what the bar is drawing right now
+    PowerFrame.progressTarget = 0   -- what the data says it should be
 
     -- Removed stat points display - stats auto-apply now
 
@@ -639,6 +709,22 @@ local function CreatePowerDisplay()
     -- Main update loop for smooth animations (similar to SpeedBuff)
     local updateTimer = 0
     PowerFrame:SetScript("OnUpdate", function(self, elapsed)
+        -- Fill the progress bar smoothly rather than snapping (Issue #18)
+        if self.isProgressTweening and self.progressBar then
+            self.progressTweenTime = self.progressTweenTime + elapsed
+            local progress = math.min(self.progressTweenTime / PROGRESS_TWEEN_DURATION, 1.0)
+            local eased = ElegastCore.Easing.EaseInOutQuad(progress)
+            local from = self.progressTweenFrom or 0
+            self.progressShown = from + (self.progressTarget - from) * eased
+            self.progressBar:SetValue(self.progressShown)
+
+            if progress >= 1.0 then
+                self.progressShown = self.progressTarget
+                self.progressBar:SetValue(self.progressShown)
+                self.isProgressTweening = false
+            end
+        end
+
         -- Handle scale animation (bounce effect)
         if self.isAnimating then
             self.animationTime = self.animationTime + elapsed


### PR DESCRIPTION
## What this does

Adds a progress bar to the Infinite Power widget so accumulation is visible
without hovering.

The data has always been there — the server sends `KILLS:total:current:needed`
and `QUESTS:total:current:needed` on every kill and quest turn-in, and this
module has parsed both since it was written (`:288-296`). The only place it
surfaced was the tooltip:

```lua
-- :503-505, before this PR the sole display of progress
GameTooltip:AddLine("Kills: " .. playerData.killsThisStack .. "/" .. playerData.killsNeeded ...)
```

`grep -n StatusBar modules/InfinitePower/InfinitePower.lua` returned nothing.
So the widget showed what you *had* and nothing about what you were *earning*.
The stack-gain animation from #4 gives the payoff; this is the build-up.

## Design notes

**One bar, not two.** Kills and quests are alternative paths to the same stack —
the tooltip already says *"Next Stack (complete either)"* — so the bar tracks
whichever is closer, and takes that path's colour straight from the tooltip's
existing legend: yellow `1, 1, 0.4` for kills, cyan `0.4, 1, 1` for quests. Bar
and tooltip agree at a glance.

**Fills, doesn't snap.** Tweens through the `PowerFrame` `OnUpdate` that already
runs the scale and border-glow animations, using
`ElegastCore.Easing.EaseInOutQuad`.

**Minimal mode moves it, doesn't hide it** — `-4` instead of `-26`, since minimal
mode drops the icon and pulls the text into the frame.

**No protocol change**, no new fields, nothing recomputed client-side.

+84 lines, one file, version `1.1.2` → `1.2.0`.

## Verification

**The pure logic was exercised for real**, not just read. `CalculateProgress`
extracted and run under liblua5.4 with a stubbed `playerData`:

```
fresh character           -> 0.000  colour 1.0/1.0/0.4 (kills)
kills leading             -> 0.400  colour 1.0/1.0/0.4 (kills)
quests leading            -> 0.667  colour 0.4/1.0/1.0 (quests)
kills at threshold        -> 1.000  colour 1.0/1.0/0.4 (kills)
kills past threshold      -> 1.000  colour 1.0/1.0/0.4 (kills)   <- clamped
server sent zero required -> 0.000  colour 1.0/1.0/0.4 (kills)   <- no div-by-zero
```

Both files parse cleanly (real Lua parser, via ctypes):

```
PARSE OK   InfinitePower.lua
PARSE OK   Core.lua
```

## What is NOT verified

**Nothing here has been seen in a client.** No WoW client in this environment.
Unproven: that the bar renders, that `TOP/BOTTOM -26` clears the `+X%` text
without overlap, that `-4` is right for minimal mode, and that 60px reads at all
at 6px tall. **All of that needs one login to check**, and the offsets are the
most likely thing to need a nudge.

This repo has no test harness at all, so the logic evidence above is a manual
run pasted here rather than something that re-runs on the next change — filed
separately as an issue.

## Context

Found while working `elegast-me/ElegastCore-Classless#127`. That issue was
originally filed on the wrong premise — that nothing consumed the `INF_PWR`
feed — because this repo is not documented anywhere in the server tree
(`elegast-me/ElegastCore-Classless#130`). A duplicate server-pushed HUD was
built and closed unmerged before this, the actual gap, turned up.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01664EbuhiHuYuTPrz3L7mQK
